### PR TITLE
Unify Study Registration in Framework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-    // swift-tools-version:5.10
+// swift-tools-version:5.10
 
 import PackageDescription
 

--- a/Sources/OpenResearchKit/Models/Composition/GeneralStudy.swift
+++ b/Sources/OpenResearchKit/Models/Composition/GeneralStudy.swift
@@ -142,6 +142,7 @@ extension GeneralStudy {
         }
         set {
             store.update(Study.Keys.CompletionDate, value: newValue)
+            publishChangesOnMain()
         }
     }
     

--- a/Sources/OpenResearchKit/Models/Studies/LongTermWithMidSurveyStudy.swift
+++ b/Sources/OpenResearchKit/Models/Studies/LongTermWithMidSurveyStudy.swift
@@ -75,8 +75,7 @@ open class LongTermWithMidSurveyStudy: LongTermStudy, HasMidSurvey {
     }
     
     var midSurveyBannerView: AnyView {
-        StudyBannerInvitation(surveyType: .mid)
-            .environmentObject(self)
+        StudyBannerInvitation(study: self, surveyType: .mid)
             .toAnyView()
     }
     

--- a/Sources/OpenResearchKit/Models/Studies/Study.swift
+++ b/Sources/OpenResearchKit/Models/Studies/Study.swift
@@ -43,10 +43,6 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
         self.additionalQueryItems = additionalQueryItems
     }
     
-    open func allPossibleTreatmentGroups() -> [TreatmentGroupOption] {
-        []
-    }
-    
     open func currentDisplayStatus() async throws -> StudyStatus {
         
         if isCompleted {
@@ -106,6 +102,10 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
         }
     }
     
+    open var hasExpired: Bool {
+        return false
+    }
+    
     public var isActive: Bool {
         
         let consentedNotDismissed = self.hasUserGivenConsent // && !self.isDismissedByUser
@@ -135,7 +135,7 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     /// A `Study` will only get recommended if and only if the user is eligible via `isEligible` and the `Study` is
     /// not removed from recommendations via `removeFromRecommendations`.
     private var meetsRecommendationCriteria: Bool {
-        return isEligible() && !removeFromRecommendations()
+        return isEligible() && !removeFromRecommendations() && !hasExpired
     }
     
     // MARK: - Persistence -

--- a/Sources/OpenResearchKit/Models/Studies/Study.swift
+++ b/Sources/OpenResearchKit/Models/Studies/Study.swift
@@ -120,7 +120,7 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     /// It prevent users from participating in the study if they are not eligible
     /// If a non-eligible user tries to start participating in a `Study` manually (e.g. via a Deep Link), an alert will be shown indicating that the user
     /// does not match the conditions set for participating in the study. This should enfore scientific soundness.
-    @MainActor open func isEligible() -> Bool {
+    open func isEligible() -> Bool {
         return participationIsPossible
     }
     
@@ -128,13 +128,13 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     /// in one sec. If set to `true`, the `Study` can only be started via a manual start (e.g. using an activation url).
     /// A `Study` will only get recommended if and only if the user is eligible via `isEligible` and the `Study` is not removed from recommendations
     /// via `removeFromRecommendations`.
-    @MainActor open func removeFromRecommendations() -> Bool {
+    open func removeFromRecommendations() -> Bool {
         return false
     }
     
     /// A `Study` will only get recommended if and only if the user is eligible via `isEligible` and the `Study` is
     /// not removed from recommendations via `removeFromRecommendations`.
-    @MainActor private var meetsRecommendationCriteria: Bool {
+    private var meetsRecommendationCriteria: Bool {
         return isEligible() && !removeFromRecommendations()
     }
     
@@ -266,8 +266,7 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     
     open var invitationBannerView: AnyView {
         
-        StudyBannerInvitation(surveyType: .introductory)
-            .environmentObject(self)
+        StudyBannerInvitation(study: self, surveyType: .introductory)
             .toAnyView()
         
     }
@@ -572,8 +571,7 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     // MARK: - HasTerminationSurvey
     
     open var terminationBannerView: AnyView {
-        StudyBannerInvitation(surveyType: .completion)
-            .environmentObject(self)
+        StudyBannerInvitation(study: self, surveyType: .completion)
             .toAnyView()
     }
     
@@ -605,7 +603,6 @@ extension Study {
 
 extension Study {
     
-    @MainActor
     public static func filterRecommended(studies: [Study]) -> [Study] {
         
         var result: [Study] = []

--- a/Sources/OpenResearchKit/Persistance/StudyFileManager.swift
+++ b/Sources/OpenResearchKit/Persistance/StudyFileManager.swift
@@ -216,7 +216,7 @@ public class StudyFileManager {
     /// Using this assumes that all data residing in the upload directory was already consented for sharing.
     public func uploadAllRemainingFiles() async throws {
         
-        for study in studyRegistry.studies {
+        for study in await studyRegistry.studies {
             
             // Upload each study folder individually and catch errors here to not block other study uploads.
             do {

--- a/Sources/OpenResearchKit/Persistance/StudyFileManager.swift
+++ b/Sources/OpenResearchKit/Persistance/StudyFileManager.swift
@@ -29,11 +29,15 @@ public class StudyFileManager {
     
     public static let shared = StudyFileManager()
     
-    public init(studyRegistry: StudyRegistry = StudyRegistry.shared) {
-        self.studyRegistry = studyRegistry
+    public init(
+        studiesProvider: @escaping @MainActor @Sendable () -> [Study] = {
+            StudyRegistry.shared.studies
+        }
+    ) {
+        self.studiesProvider = studiesProvider
     }
     
-    private let studyRegistry: StudyRegistry
+    private let studiesProvider: @MainActor @Sendable () -> [Study]
     private let fileManager: FileManager = .default
     
     /// Deletes all files present in the study directory (either the `upload` or the `working` directory).
@@ -216,7 +220,7 @@ public class StudyFileManager {
     /// Using this assumes that all data residing in the upload directory was already consented for sharing.
     public func uploadAllRemainingFiles() async throws {
         
-        for study in await studyRegistry.studies {
+        for study in await studiesProvider() {
             
             // Upload each study folder individually and catch errors here to not block other study uploads.
             do {

--- a/Sources/OpenResearchKit/Persistance/StudyKeyValueStore.swift
+++ b/Sources/OpenResearchKit/Persistance/StudyKeyValueStore.swift
@@ -62,14 +62,14 @@ public final class StudyKeyValueStore {
     ///   - key: The value key inside the study dictionary.
     ///   - type: The expected value type (for readability at call sites).
     /// - Returns: The typed value if present and castable, otherwise `nil`.
-    func get<T>(_ key: String, type: T.Type) -> T? {
+    public func get<T>(_ key: String, type: T.Type) -> T? {
         return values()[key] as? T
     }
     
     /// Replaces **all** stored values for this study.
     ///
     /// - Parameter values: The entire dictionary to persist for this study.
-    func saveValues(_ values: [String: Any]) {
+    func replaceValues(_ values: [String: Any]) {
         var currentDefaults = defaults.dictionary(forKey: Self.key) as? OpenResearchDefaults ?? [:]
         currentDefaults[studyIdentifier] = values
         defaults.set(currentDefaults, forKey: Self.key)
@@ -80,7 +80,7 @@ public final class StudyKeyValueStore {
     /// - Parameters:
     ///   - key: The key to update.
     ///   - value: New value. Pass `nil` to **remove** the key from the study’s dictionary.
-    func update(_ key: String, value: Any?) {
+    public func update(_ key: String, value: Any?) {
         self.updateValues { values in
             values[key] = value // assigning nil removes the key
         }

--- a/Sources/OpenResearchKit/Utility/Collection+Study+Extensions.swift
+++ b/Sources/OpenResearchKit/Utility/Collection+Study+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  Collection+Study+Extensions.swift
+//  OpenResearchKit
+//
+//  Created by Lennart Fischer on 10.04.26.
+//
+
+
+public extension Collection where Element == Study {
+    
+    func randomStudy<R: RandomNumberGenerator>(using randomNumberGenerator: inout R) -> Study? {
+        
+        guard !isEmpty else {
+            return nil
+        }
+        
+        let next = randomNumberGenerator.next()
+        let offset = Int(next % UInt64(count))
+        let index = self.index(startIndex, offsetBy: offset)
+        
+        return self[index]
+    }
+    
+}

--- a/Sources/OpenResearchKit/Utility/Migrations/2025_09_29_V2_Migration.swift
+++ b/Sources/OpenResearchKit/Utility/Migrations/2025_09_29_V2_Migration.swift
@@ -9,15 +9,19 @@ class AdaptNewDataFormatMigration: DataMigration {
     
     var id: String = "2025_09_29_V2_Migration"
     
-    private let studyRegistry: StudyRegistry
+    private let studiesProvider: @MainActor @Sendable () -> [Study]
     
-    public init(studyRegistry: StudyRegistry = StudyRegistry.shared) {
-        self.studyRegistry = studyRegistry
+    public init(
+        studiesProvider: @escaping @MainActor @Sendable () -> [Study] = {
+            StudyRegistry.shared.studies
+        }
+    ) {
+        self.studiesProvider = studiesProvider
     }
     
     func perform() async throws {
         
-        for study in await studyRegistry.studies {
+        for study in await studiesProvider() {
             self.updateStudy(study)
         }
         

--- a/Sources/OpenResearchKit/Utility/Migrations/2025_09_29_V2_Migration.swift
+++ b/Sources/OpenResearchKit/Utility/Migrations/2025_09_29_V2_Migration.swift
@@ -17,7 +17,7 @@ class AdaptNewDataFormatMigration: DataMigration {
     
     func perform() async throws {
         
-        for study in studyRegistry.studies {
+        for study in await studyRegistry.studies {
             self.updateStudy(study)
         }
         

--- a/Sources/OpenResearchKit/Utility/StudyRegistry.swift
+++ b/Sources/OpenResearchKit/Utility/StudyRegistry.swift
@@ -9,34 +9,50 @@ import Foundation
 import SwiftUI
 import Combine
 
+
 public class StudyRegistry: ObservableObject {
     
     public static let shared = StudyRegistry()
     
     // MARK: - Registry -
     
-    private var cancellables: Set<AnyCancellable> = Set()
-    
     public var studies: [Study] = []
-    
-    public init(studies: [Study] = []) {
-        self.studies = studies
-        NotificationCenter.default.publisher(for: .userConsented).sink { [weak self] notification in
-            self?.objectWillChange.send()
-        }
-        .store(in: &cancellables)
-    }
-    
-    public func registerStudies(_ studies: [Study]) {
-        self.studies = studies
-        self.objectWillChange.send()
-    }
     
     public var currentActiveStudy: Study? {
         studies
             .first { study in
                 return study.isActive
             }
+    }
+    
+    public var recommendedStudies: [Study] {
+        Study.filterRecommended(studies: studies)
+    }
+    
+    public private(set) var recommendedStudy: Study?
+    
+    private var randomNumberGenerator: RandomNumberGenerator
+    private var cancellables: Set<AnyCancellable> = Set()
+    
+    public init(studies: [Study] = [], randomNumberGenerator: RandomNumberGenerator = SystemRandomNumberGenerator()) {
+        self.studies = studies
+        self.randomNumberGenerator = randomNumberGenerator
+        self.reloadRecommendedStudy()
+        NotificationCenter.default.publisher(for: .userConsented).sink { [weak self] notification in
+            self?.objectWillChange.send()
+        }
+        .store(in: &cancellables)
+    }
+    
+    // MARK: - Actions -
+    
+    public func registerStudies(_ studies: [Study]) {
+        self.studies.append(contentsOf: studies)
+        self.objectWillChange.send()
+    }
+    
+    public func reloadRecommendedStudy() {
+        self.recommendedStudy = recommendedStudies.randomElement(using: &randomNumberGenerator)
     }
     
 }

--- a/Sources/OpenResearchKit/Utility/StudyRegistry.swift
+++ b/Sources/OpenResearchKit/Utility/StudyRegistry.swift
@@ -16,7 +16,12 @@ public class StudyRegistry: ObservableObject {
     
     // MARK: - Registry -
     
-    public var studies: [Study] = []
+    public private(set) var studies: [Study] = [] {
+        didSet {
+            syncStudyObservers()
+            refreshDerivedState()
+        }
+    }
     
     public var currentActiveStudy: Study? {
         studies
@@ -31,28 +36,84 @@ public class StudyRegistry: ObservableObject {
     
     public private(set) var recommendedStudy: Study?
     
-    private var randomNumberGenerator: RandomNumberGenerator
-    private var cancellables: Set<AnyCancellable> = Set()
+    private var randomNumberGenerator: any RandomNumberGenerator
+    private var studyObserverCancellables: [ObjectIdentifier: AnyCancellable] = [:]
     
-    public init(studies: [Study] = [], randomNumberGenerator: RandomNumberGenerator = SystemRandomNumberGenerator()) {
+    public init(
+        studies: [Study] = [],
+        randomNumberGenerator: any RandomNumberGenerator = SystemRandomNumberGenerator()
+    ) {
         self.studies = studies
         self.randomNumberGenerator = randomNumberGenerator
-        self.reloadRecommendedStudy()
-        NotificationCenter.default.publisher(for: .userConsented).sink { [weak self] notification in
-            self?.objectWillChange.send()
-        }
-        .store(in: &cancellables)
+        self.syncStudyObservers()
+        self.refreshDerivedState()
     }
     
     // MARK: - Actions -
     
     public func registerStudies(_ studies: [Study]) {
         self.studies.append(contentsOf: studies)
-        self.objectWillChange.send()
     }
     
     public func reloadRecommendedStudy() {
-        self.recommendedStudy = recommendedStudies.randomElement(using: &randomNumberGenerator)
+        self.recommendedStudy = recommendedStudies.randomStudy(using: &randomNumberGenerator)
+    }
+    
+    // MARK: - Helpers -
+    
+    private func syncStudyObservers() {
+        let currentStudyIdentifiers = Set(studies.map { ObjectIdentifier($0) })
+        let staleIdentifiers = studyObserverCancellables.keys.filter { !currentStudyIdentifiers.contains($0) }
+        
+        for identifier in staleIdentifiers {
+            studyObserverCancellables[identifier]?.cancel()
+            studyObserverCancellables.removeValue(forKey: identifier)
+        }
+        
+        for study in studies {
+            let identifier = ObjectIdentifier(study)
+            
+            guard studyObserverCancellables[identifier] == nil else {
+                continue
+            }
+            
+            studyObserverCancellables[identifier] = study.objectWillChange
+                .sink { [weak self] _ in
+                    self?.refreshDerivedState()
+                }
+        }
+    }
+    
+    private func refreshDerivedState() {
+        let availableRecommendedStudies = recommendedStudies
+        
+        if let recommendedStudy,
+           availableRecommendedStudies.contains(where: { $0 === recommendedStudy }) {
+            self.recommendedStudy = recommendedStudy
+        } else {
+            self.recommendedStudy = availableRecommendedStudies.randomStudy(using: &randomNumberGenerator)
+        }
+        
+        DispatchQueue.main.async {
+            self.objectWillChange.send()
+        }
+    }
+    
+}
+
+public extension Collection where Element == Study {
+    
+    func randomStudy<R: RandomNumberGenerator>(using randomNumberGenerator: inout R) -> Study? {
+        
+        guard !isEmpty else {
+            return nil
+        }
+        
+        let next = randomNumberGenerator.next()
+        let offset = Int(next % UInt64(count))
+        let index = self.index(startIndex, offsetBy: offset)
+        
+        return self[index]
     }
     
 }

--- a/Sources/OpenResearchKit/Utility/StudyRegistry.swift
+++ b/Sources/OpenResearchKit/Utility/StudyRegistry.swift
@@ -101,19 +101,3 @@ public class StudyRegistry: ObservableObject {
     
 }
 
-public extension Collection where Element == Study {
-    
-    func randomStudy<R: RandomNumberGenerator>(using randomNumberGenerator: inout R) -> Study? {
-        
-        guard !isEmpty else {
-            return nil
-        }
-        
-        let next = randomNumberGenerator.next()
-        let offset = Int(next % UInt64(count))
-        let index = self.index(startIndex, offsetBy: offset)
-        
-        return self[index]
-    }
-    
-}

--- a/Sources/OpenResearchKit/Views/ActiveStudyDisclaimerView.swift
+++ b/Sources/OpenResearchKit/Views/ActiveStudyDisclaimerView.swift
@@ -11,12 +11,14 @@ public struct ActiveStudyDisclaimerView<Background: View>: View {
     
     @State var showSheet = false
     
-    @EnvironmentObject var study: Study
+    @EnvironmentObject var studyRegistry: StudyRegistry
     
+    public let study: Study
     public let foregroundColor: Color
     public let background: () -> Background
     
-    public init(foregroundColor: Color, @ViewBuilder background: @escaping () -> Background) {
+    public init(study: Study, foregroundColor: Color, @ViewBuilder background: @escaping () -> Background) {
+        self.study = study
         self.foregroundColor = foregroundColor
         self.background = background
     }
@@ -83,6 +85,17 @@ public struct ActiveStudyDisclaimerView<Background: View>: View {
     List {
         
         ActiveStudyDisclaimerView(
+            study: Study(
+                studyIdentifier: "test",
+                studyInformation: StudyInformation(
+                    title: "Example Study",
+                    subtitle: "Take part in this example study.",
+                    contactEmail: "info@example.org",
+                    image: nil
+                ),
+                uploadConfiguration: .init(fileSubmissionServer: URL(string: "https://example.org")!, uploadFrequency: 24 * 60 * 60, apiKey: ""),
+                introductorySurveyURL: URL(string: "https://example.org")
+            ),
             foregroundColor: .white
         ) {
             Color.cyan

--- a/Sources/OpenResearchKit/Views/StudyBannerInvitation.swift
+++ b/Sources/OpenResearchKit/Views/StudyBannerInvitation.swift
@@ -12,8 +12,12 @@ import UIKit
 public struct StudyBannerInvitation: View {
     
     let surveyType: SurveyType
+    let study: Study
     
-    @EnvironmentObject var study: Study
+    init(study: Study, surveyType: SurveyType) {
+        self.surveyType = surveyType
+        self.study = study
+    }
     
     public var body: some View {
         
@@ -204,18 +208,15 @@ fileprivate let study = DataDonationStudy(
     List {
         
         Section {
-            StudyBannerInvitation(surveyType: .introductory)
-                .environmentObject(study as Study)
+            StudyBannerInvitation(study: study, surveyType: .introductory)
         }
         
         Section {
-            StudyBannerInvitation(surveyType: .mid)
-                .environmentObject(study as Study)
+            StudyBannerInvitation(study: study, surveyType: .mid)
         }
         
         Section {
-            StudyBannerInvitation(surveyType: .completion)
-                .environmentObject(study as Study)
+            StudyBannerInvitation(study: study, surveyType: .completion)
         }
         
     }
@@ -226,8 +227,7 @@ fileprivate let study = DataDonationStudy(
     
     List {
         
-        StudyBannerInvitation(surveyType: .introductory)
-            .environmentObject(study as Study)
+        StudyBannerInvitation(study: study, surveyType: .introductory)
         
     }
     .preferredColorScheme(.dark)

--- a/Tests/OpenResearchKitTests/Models/Studies/StudyTests.swift
+++ b/Tests/OpenResearchKitTests/Models/Studies/StudyTests.swift
@@ -64,13 +64,20 @@ final class StudyTests: XCTestCase {
         
     }
     
-    private final class TreatmentGroupStudy: LongTermStudy {
+    private final class TreatmentGroupStudy: LongTermStudy, HasTreatmentGroups {
         
-        override func allPossibleTreatmentGroups() -> [TreatmentGroupOption] {
-            [
-                TreatmentGroupOption(id: "control", displayName: "Control"),
-                TreatmentGroupOption(id: "intervention", displayName: "Intervention")
-            ]
+        enum TreatmentGroup: String, StudyTreatmentGroup {
+            case control
+            case intervention
+            
+            var displayName: String {
+                switch self {
+                    case .control:
+                        return "Control"
+                    case .intervention:
+                        return "Intervention"
+                }
+            }
         }
         
     }
@@ -169,11 +176,7 @@ final class StudyTests: XCTestCase {
 
     }
     
-    func test_allPossibleTreatmentGroups_isEmptyByDefault() {
-        XCTAssertEqual(study.allPossibleTreatmentGroups(), [])
-    }
-    
-    func test_allPossibleTreatmentGroups_canBeCustomizedPerStudy() {
+    func test_treatmentGroupsCanBeCustomizedPerStudy() {
         
         let customStudy = TreatmentGroupStudy(
             studyIdentifier: "treatment-\(UUID().uuidString)",
@@ -192,21 +195,12 @@ final class StudyTests: XCTestCase {
             introductorySurveyURL: URL(string: "https://example.com/intro")!,
             concludingSurveyURL: URL(string: "https://example.com/conclusion")!
         )
-        let baseStudy: Study = customStudy
         
-        XCTAssertEqual(
-            baseStudy.allPossibleTreatmentGroups(),
-            [
-                TreatmentGroupOption(id: "control", displayName: "Control"),
-                TreatmentGroupOption(id: "intervention", displayName: "Intervention")
-            ]
-        )
-        
-        customStudy.assignedGroup = "control"
+        customStudy.selectedTreatmentGroup = .control
         
         XCTAssertEqual(
             customStudy.selectedTreatmentGroup,
-            TreatmentGroupOption(id: "control", displayName: "Control")
+            .control
         )
     }
 

--- a/Tests/OpenResearchKitTests/Persistence/StudyKeyValueStoreTests.swift
+++ b/Tests/OpenResearchKitTests/Persistence/StudyKeyValueStoreTests.swift
@@ -38,7 +38,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
     func testSaveAndReadRoundtrip() {
         let store = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
         let now = Date()
-        store.saveValues([
+        store.replaceValues([
             "lastUploadDate": now,
             "count": 3,
             "flag": true,
@@ -54,7 +54,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
     
     func testUpdateValuesMergesChanges() {
         let store = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
-        store.saveValues(["count": 1, "name": "Start"])
+        store.replaceValues(["count": 1, "name": "Start"])
         
         store.updateValues { dict in
             dict["count"] = (dict["count"] as? Int ?? 0) + 1
@@ -69,7 +69,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
     
     func testTypedGet() {
         let store = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
-        store.saveValues(["count": 7, "name": "Bob", "flag": false])
+        store.replaceValues(["count": 7, "name": "Bob", "flag": false])
         
         XCTAssertEqual(store.get("count", type: Int.self), 7)
         XCTAssertEqual(store.get("name", type: String.self), "Bob")
@@ -80,7 +80,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
     
     func testUpdateSingleKeyAndRemove() {
         let store = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
-        store.saveValues(["a": 1, "b": 2])
+        store.replaceValues(["a": 1, "b": 2])
         
         // set/replace
         store.update("b", value: 42)
@@ -96,8 +96,8 @@ final class StudyKeyValueStoreTests: XCTestCase {
         let a = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
         let b = StudyKeyValueStore(studyIdentifier: "study-B", appGroup: suiteName)
         
-        a.saveValues(["onlyA": true])
-        b.saveValues(["onlyB": true])
+        a.replaceValues(["onlyA": true])
+        b.replaceValues(["onlyB": true])
         
         XCTAssertEqual(a.get("onlyA", type: Bool.self), true)
         XCTAssertNil(a.get("onlyB", type: Bool.self))
@@ -108,7 +108,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
     
     func testDeleteAllValuesRemovesStudyDictionary() {
         let store = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
-        store.saveValues(["a": 1, "b": 2])
+        store.replaceValues(["a": 1, "b": 2])
         XCTAssertFalse(store.values().isEmpty)
         
         store.deleteAllValues()
@@ -126,7 +126,7 @@ final class StudyKeyValueStoreTests: XCTestCase {
         XCTAssertTrue(store.values().isEmpty)
         
         // Create then delete twice
-        store.saveValues(["x": 42])
+        store.replaceValues(["x": 42])
         XCTAssertEqual(store.get("x", type: Int.self), 42)
         
         store.deleteAllValues()
@@ -141,8 +141,8 @@ final class StudyKeyValueStoreTests: XCTestCase {
         let a = StudyKeyValueStore(studyIdentifier: "study-A", appGroup: suiteName)
         let b = StudyKeyValueStore(studyIdentifier: "study-B", appGroup: suiteName)
         
-        a.saveValues(["onlyA": true])
-        b.saveValues(["onlyB": true])
+        a.replaceValues(["onlyA": true])
+        b.replaceValues(["onlyB": true])
         
         a.deleteAllValues()
         

--- a/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
+++ b/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
@@ -1,0 +1,278 @@
+//
+//  StudyRegistryTests.swift
+//  OpenResearchKit
+//
+//  Created by Codex on 09.04.26.
+//
+
+import XCTest
+import Combine
+@testable import OpenResearchKit
+
+@MainActor
+final class StudyRegistryTests: XCTestCase {
+    
+    private var cancellables: Set<AnyCancellable> = []
+    private var studiesToReset: [Study] = []
+    
+    override func tearDown() {
+        for study in studiesToReset {
+            try? study.reset()
+        }
+        
+        studiesToReset = []
+        cancellables.removeAll()
+        
+        super.tearDown()
+    }
+    
+    func testRegistryRefreshesAfterConsent() {
+        let study = makeDataDonationStudy()
+        let registry = makeRegistry(studies: [study])
+        
+        XCTAssertNil(registry.currentActiveStudy)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+        
+        assertRegistryRefresh(on: registry) {
+            self.giveConsent(to: study)
+        }
+        
+        XCTAssertTrue(registry.currentActiveStudy === study)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+    }
+    
+    func testRegistryRefreshesAfterDismissal() {
+        let study = makeDataDonationStudy()
+        let registry = makeRegistry(studies: [study])
+        
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+        
+        assertRegistryRefresh(on: registry) {
+            study.isDismissedByUser = true
+        }
+        
+        XCTAssertNil(registry.currentActiveStudy)
+        XCTAssertTrue(registry.recommendedStudies.isEmpty)
+        XCTAssertNil(registry.recommendedStudy)
+    }
+    
+    func testRegistryRefreshesAfterTerminationBeforeCompletion() {
+        let study = makeDataDonationStudy()
+        giveConsent(to: study)
+        
+        let registry = makeRegistry(studies: [study])
+        
+        XCTAssertTrue(registry.currentActiveStudy === study)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+        
+        assertRegistryRefresh(on: registry) {
+            study.terminateParticipationImmediately()
+        }
+        
+        XCTAssertNil(registry.currentActiveStudy)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+    }
+    
+    func testRegistryRefreshesWhenStudyIsCompletedViaSetCompleted() {
+        let study = makeDataDonationStudy()
+        giveConsent(to: study)
+        
+        let registry = makeRegistry(studies: [study])
+        
+        XCTAssertTrue(registry.currentActiveStudy === study)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+        
+        assertRegistryRefresh(on: registry) {
+            study.setCompleted()
+        }
+        
+        XCTAssertNil(registry.currentActiveStudy)
+        XCTAssertTrue(registry.recommendedStudies.isEmpty)
+        XCTAssertNil(registry.recommendedStudy)
+    }
+    
+    func testRegistryRefreshesAfterTerminationSurveyCompletion() {
+        let study = makeLongTermStudy(duration: 60)
+        giveConsent(to: study, at: Date().addingTimeInterval(-120))
+        
+        let registry = makeRegistry(studies: [study])
+        
+        XCTAssertTrue(registry.currentActiveStudy === study)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+        
+        assertRegistryRefresh(on: registry) {
+            study.completeTerminationSurvey()
+        }
+        
+        XCTAssertNil(registry.currentActiveStudy)
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [study.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === study)
+    }
+    
+    func testRegistryDoesNotRerandomizeRecommendedStudyForNonEligibilityChanges() {
+        let firstStudy = makeDataDonationStudy()
+        let secondStudy = makeDataDonationStudy()
+        let thirdStudy = makeDataDonationStudy()
+        let generator = CountingRandomNumberGenerator(values: [0, 2, 1, 0])
+        let registry = makeRegistry(studies: [firstStudy, secondStudy, thirdStudy], randomNumberGenerator: generator)
+        
+        guard let initialRecommendedStudy = registry.recommendedStudy else {
+            XCTFail("Expected an initial recommended study.")
+            return
+        }
+        
+        XCTAssertEqual(generator.nextCallCount, 1)
+        
+        assertRegistryRefresh(on: registry) {
+            firstStudy.markUploadSuccessful(newDate: Date())
+        }
+        
+        XCTAssertEqual(generator.nextCallCount, 1)
+        XCTAssertTrue(registry.recommendedStudy === initialRecommendedStudy)
+        XCTAssertEqual(
+            Set(registry.recommendedStudies.map(\.studyIdentifier)),
+            Set([firstStudy.studyIdentifier, secondStudy.studyIdentifier, thirdStudy.studyIdentifier])
+        )
+    }
+    
+    // MARK: - Helpers -
+    
+    private func makeRegistry(
+        studies: [Study],
+        randomNumberGenerator: any RandomNumberGenerator = CountingRandomNumberGenerator(values: [0])
+    ) -> StudyRegistry {
+        StudyRegistry(studies: studies, randomNumberGenerator: randomNumberGenerator)
+    }
+    
+    private func makeDataDonationStudy() -> QuietDataDonationStudy {
+        let identifier = "study-registry-data-donation-\(UUID().uuidString)"
+        
+        let study = QuietDataDonationStudy(
+            studyIdentifier: identifier,
+            studyInformation: StudyInformation(
+                title: "Data Donation",
+                subtitle: "Donate your data for science.",
+                contactEmail: "test@example.com",
+                image: nil
+            ),
+            uploadConfiguration: UploadConfiguration(
+                fileSubmissionServer: URL(string: "https://example.com/upload")!,
+                uploadFrequency: 3600,
+                apiKey: "TEST_API_KEY"
+            ),
+            introductorySurveyURL: URL(string: "https://example.com/intro")!,
+            participationIsPossible: true
+        )
+        
+        studiesToReset.append(study)
+        
+        return study
+    }
+    
+    private func makeLongTermStudy(duration: TimeInterval) -> QuietLongTermStudy {
+        let identifier = "study-registry-long-term-\(UUID().uuidString)"
+        
+        let study = QuietLongTermStudy(
+            studyIdentifier: identifier,
+            studyInformation: StudyInformation(
+                title: "Long Term Study",
+                subtitle: "Track behavior over time.",
+                contactEmail: "test@example.com",
+                image: nil
+            ),
+            uploadConfiguration: UploadConfiguration(
+                fileSubmissionServer: URL(string: "https://example.com/upload")!,
+                uploadFrequency: 3600,
+                apiKey: "TEST_API_KEY"
+            ),
+            duration: duration,
+            introductorySurveyURL: URL(string: "https://example.com/intro")!,
+            concludingSurveyURL: URL(string: "https://example.com/completion")!,
+            participationIsPossible: true
+        )
+        
+        studiesToReset.append(study)
+        
+        return study
+    }
+    
+    private func giveConsent(to study: Study, at date: Date = Date()) {
+        let expectation = expectation(description: "Study consent saved")
+        
+        study.saveUserConsentHasBeenGiven(consentTimestamp: date) {
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    private func assertRegistryRefresh(
+        on registry: StudyRegistry,
+        perform action: () -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let expectation = expectation(description: "Registry refreshed")
+        expectation.assertForOverFulfill = false
+        
+        registry.objectWillChange
+            .sink { _ in
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        action()
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+}
+
+private final class QuietDataDonationStudy: DataDonationStudy {
+    
+    override func didTerminateParticipation(terminationDate: Date) {
+        
+    }
+    
+}
+
+private final class QuietLongTermStudy: LongTermStudy {
+    
+    override func shouldHaveNotifications() -> Bool {
+        false
+    }
+    
+    override func didTerminateParticipation(terminationDate: Date) {
+        
+    }
+    
+}
+
+private final class CountingRandomNumberGenerator: RandomNumberGenerator {
+    
+    private let values: [UInt64]
+    private var currentIndex: Int = 0
+    
+    private(set) var nextCallCount: Int = 0
+    
+    init(values: [UInt64]) {
+        self.values = values.isEmpty ? [0] : values
+    }
+    
+    func next() -> UInt64 {
+        let value = values[currentIndex]
+        
+        nextCallCount += 1
+        currentIndex = (currentIndex + 1) % values.count
+        
+        return value
+    }
+    
+}

--- a/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
+++ b/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
@@ -237,6 +237,10 @@ final class StudyRegistryTests: XCTestCase {
 
 private final class QuietDataDonationStudy: DataDonationStudy {
     
+    override func shouldHaveNotifications() -> Bool {
+        false
+    }
+    
     override func didTerminateParticipation(terminationDate: Date) {
         
     }


### PR DESCRIPTION
This PR improves upon the concept of the `StudyRegistry` which serves as the single point for a `Study` to be registered with. It handles the active `Study`, recommendations/available studies and observes their status as an `ObservableObject` to be used with SwiftUI. 