### PR TITLE
Fix `SurveyWebView` Crash Caused by `@EnvironmentObject` Injection

### DIFF
--- a/Sources/OpenResearchKit/Models/Composition/HasMidSurvey.swift
+++ b/Sources/OpenResearchKit/Models/Composition/HasMidSurvey.swift
@@ -59,9 +59,9 @@ extension HasMidSurvey {
     }
     
     public func showMidStudySurvey() {
-        
-        self.showView(SurveyWebView(surveyType: .mid).environmentObject(self))
-        
+        if let study = self as? Study {
+            self.showView(SurveyWebView(surveyType: .mid, study: study))
+        }
     }
     
     public func completeMidSurvey() {

--- a/Sources/OpenResearchKit/Models/Composition/HasTerminationSurvey.swift
+++ b/Sources/OpenResearchKit/Models/Composition/HasTerminationSurvey.swift
@@ -52,9 +52,9 @@ extension HasTerminationSurvey {
     }
     
     public func showCompletionSurvey() {
-        
-        showView(SurveyWebView(surveyType: .completion).environmentObject(self))
-        
+        if let study = self as? Study {
+            self.showView(SurveyWebView(surveyType: .completion, study: study))
+        }
     }
     
     public func completeTerminationSurvey() {

--- a/Sources/OpenResearchKit/Utility/StudyPresenter.swift
+++ b/Sources/OpenResearchKit/Utility/StudyPresenter.swift
@@ -19,8 +19,9 @@ public extension StudyPresenter {
         
         let surveyView = UIHostingController(
             rootView: SurveyWebView(
-                surveyType: surveyType
-            ).environmentObject(study)
+                surveyType: surveyType,
+                study: study
+            )
         )
         
         surveyView.modalPresentationStyle = .fullScreen

--- a/Sources/OpenResearchKit/Views/SurveyWebView.swift
+++ b/Sources/OpenResearchKit/Views/SurveyWebView.swift
@@ -16,14 +16,15 @@ import UIKit
 /// mid, and completion surveys, and processes metadata returned via URL parameters to persist study state.
 public struct SurveyWebView: View {
     
-    @Environment(\.presentationMode) var presentationMode
-    @EnvironmentObject var study: Study
+    @Environment(\.presentationMode) private var presentationMode
     @State private var isInitialLoading = true
     
     let surveyType: SurveyType
+    let study: Study
     
-    public init(surveyType: SurveyType) {
+    public init(surveyType: SurveyType, study: Study) {
         self.surveyType = surveyType
+        self.study = study
     }
     
     public var body: some View {


### PR DESCRIPTION
This PR fixes a crash we were experiencing in one sec where there was a missing environment object.