### PR TITLE
Addresses two important issues

### DIFF
--- a/Sources/OpenResearchKit/Models/Studies/Study.swift
+++ b/Sources/OpenResearchKit/Models/Studies/Study.swift
@@ -619,6 +619,7 @@ extension Study {
         for study in studies {
             if study.isDismissedByUser { continue }
             if study.isCompleted { continue }
+            if study.introductorySurveyURL == nil { continue }
             if study.meetsRecommendationCriteria {
                 result.append(study)
             }

--- a/Sources/OpenResearchKit/Models/Studies/Study.swift
+++ b/Sources/OpenResearchKit/Models/Studies/Study.swift
@@ -253,7 +253,7 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     // MARK: - Callbacks -
     
     open func didTerminateParticipation(terminationDate: Date) {
-        self.appendNewJSONObjects(newObjects: [
+        self.appendNewJSONObjectsIfConsented(newObjects: [
             [
                 "terminationReason": "terminatedByUser",
                 "timestamp": terminationDate.timeIntervalSince1970
@@ -436,14 +436,15 @@ open class Study: ObservableObject, GeneralStudy, HasIntroductorySurvey, HasNoti
     }
     
     public func appendNewJSONObjects(newObjects: [[String: JSONConvertible]]) {
-        
-        if hasUserGivenConsent {
-            // only add data if study is running: user has given consent
-            var existingFile = self.JSONFile
-            existingFile.append(contentsOf: newObjects)
-            self.saveAndUploadIfNeccessary(jsonFile: existingFile)
-        }
-        
+        appendNewJSONObjectsIfConsented(newObjects: newObjects)
+    }
+
+    private func appendNewJSONObjectsIfConsented(newObjects: [[String: JSONConvertible]]) {
+        guard hasUserGivenConsent else { return }
+
+        var existingFile = self.JSONFile
+        existingFile.append(contentsOf: newObjects)
+        self.saveAndUploadIfNeccessary(jsonFile: existingFile)
     }
     
     private func saveAndUploadIfNeccessary(jsonFile: [ [String: Any] ]) {

--- a/Sources/OpenResearchKit/Views/Settings/StudyListScreen.swift
+++ b/Sources/OpenResearchKit/Views/Settings/StudyListScreen.swift
@@ -30,6 +30,15 @@ public struct StudyListScreen: View {
         self.dismissedStudies = dismissedStudies
         self.shouldShowDebugTools = Bundle.main.isInDebugMode || Bundle.main.isOnTestFlight
     }
+    
+    public init(studyRegistry: StudyRegistry) {
+        self.init(
+            activeStudy: studyRegistry.currentActiveStudy,
+            availableStudies: studyRegistry.recommendedStudies,
+            participatedStudies: Study.filterCompleted(studies: studyRegistry.studies),
+            dismissedStudies: studyRegistry.dismissedStudies
+        )
+    }
 
     init(
         activeStudy: Study?,

--- a/Tests/OpenResearchKitTests/Models/Studies/LongTermStudyTests.swift
+++ b/Tests/OpenResearchKitTests/Models/Studies/LongTermStudyTests.swift
@@ -185,6 +185,28 @@ final class LongTermStudyTests: XCTestCase {
         XCTAssertFalse(study.isActive)
         
     }
+
+    func testEarlyTerminateAppendsTerminationDataPoint() {
+        let dateGenerator = TimeTraveler()
+        let study = createLongTermStudy(duration: 10)
+        study.dateGenerator = dateGenerator
+
+        study.saveUserConsentHasBeenGiven(completion: {})
+
+        dateGenerator.travel(by: 5)
+        study.terminateParticipationImmediately()
+
+        let terminationDataPoint = study.JSONFile.last
+        XCTAssertEqual(terminationDataPoint?["terminationReason"] as? String, "terminatedByUser")
+
+        guard let timestamp = terminationDataPoint?["timestamp"] as? Double,
+              let terminationDate = study.terminationBeforeCompletionDate else {
+            XCTFail("Expected a termination timestamp and stored termination date")
+            return
+        }
+
+        XCTAssertEqual(timestamp, terminationDate.timeIntervalSince1970, accuracy: 0.001)
+    }
     
     // MARK: - Long Term without Conclusion
     

--- a/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
+++ b/Tests/OpenResearchKitTests/Utility/StudyRegistryTests.swift
@@ -75,6 +75,15 @@ final class StudyRegistryTests: XCTestCase {
         XCTAssertEqual(registry.dismissedStudies.map(\.studyIdentifier), [dismissedStudy.studyIdentifier])
         XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [visibleStudy.studyIdentifier])
     }
+
+    func testRegistryExcludesStudiesWithoutIntroSurveyFromRecommendations() {
+        let studyWithoutIntroSurvey = makeDataDonationStudy(introductorySurveyURL: nil)
+        let studyWithIntroSurvey = makeDataDonationStudy()
+        let registry = makeRegistry(studies: [studyWithoutIntroSurvey, studyWithIntroSurvey])
+
+        XCTAssertEqual(registry.recommendedStudies.map(\.studyIdentifier), [studyWithIntroSurvey.studyIdentifier])
+        XCTAssertTrue(registry.recommendedStudy === studyWithIntroSurvey)
+    }
     
     func testRegistryRefreshesAfterTerminationBeforeCompletion() {
         let study = makeDataDonationStudy()
@@ -168,7 +177,9 @@ final class StudyRegistryTests: XCTestCase {
         StudyRegistry(studies: studies, randomNumberGenerator: randomNumberGenerator)
     }
     
-    private func makeDataDonationStudy() -> QuietDataDonationStudy {
+    private func makeDataDonationStudy(
+        introductorySurveyURL: URL? = URL(string: "https://example.com/intro")!
+    ) -> QuietDataDonationStudy {
         let identifier = "study-registry-data-donation-\(UUID().uuidString)"
         
         let study = QuietDataDonationStudy(
@@ -184,7 +195,7 @@ final class StudyRegistryTests: XCTestCase {
                 uploadFrequency: 3600,
                 apiKey: "TEST_API_KEY"
             ),
-            introductorySurveyURL: URL(string: "https://example.com/intro")!,
+            introductorySurveyURL: introductorySurveyURL,
             participationIsPossible: true
         )
         

--- a/Tests/OpenResearchKitTests/Views/StudyListScreenTests.swift
+++ b/Tests/OpenResearchKitTests/Views/StudyListScreenTests.swift
@@ -10,6 +10,36 @@ import XCTest
 
 final class StudyListScreenTests: XCTestCase {
     
+    func testRegistryInitializerDerivesStudySectionsFromRegistry() {
+        let activeStudy = makeStudy(identifier: "active")
+        let availableStudy = makeStudy(identifier: "available")
+        let completedStudy = makeStudy(identifier: "completed")
+        let dismissedStudy = makeStudy(identifier: "dismissed")
+        let studies = [activeStudy, availableStudy, completedStudy, dismissedStudy]
+        defer { studies.forEach { try? $0.reset() } }
+        
+        giveConsent(to: activeStudy)
+        completedStudy.setCompleted()
+        dismissedStudy.isDismissedByUser = true
+        
+        let registry = StudyRegistry(studies: studies)
+        let screen = StudyListScreen(studyRegistry: registry)
+        
+        XCTAssertTrue(reflectedStudy(named: "activeStudy", in: screen) === registry.currentActiveStudy)
+        XCTAssertEqual(
+            reflectedStudies(named: "availableStudies", in: screen).map(\.studyIdentifier),
+            registry.recommendedStudies.map(\.studyIdentifier)
+        )
+        XCTAssertEqual(
+            reflectedStudies(named: "participatedStudies", in: screen).map(\.studyIdentifier),
+            Study.filterCompleted(studies: registry.studies).map(\.studyIdentifier)
+        )
+        XCTAssertEqual(
+            reflectedStudies(named: "dismissedStudies", in: screen).map(\.studyIdentifier),
+            registry.dismissedStudies.map(\.studyIdentifier)
+        )
+    }
+    
     func testDismissedSectionIsHiddenOutsideDebugAndTestFlight() {
         let study = makeStudy()
         defer { try? study.reset() }
@@ -44,8 +74,12 @@ final class StudyListScreenTests: XCTestCase {
     }
     
     private func makeStudy() -> Study {
+        makeStudy(identifier: UUID().uuidString)
+    }
+    
+    private func makeStudy(identifier: String) -> Study {
         DataDonationStudy(
-            studyIdentifier: "study-list-screen-\(UUID().uuidString)",
+            studyIdentifier: "study-list-screen-\(identifier)",
             studyInformation: StudyInformation(
                 title: "Study",
                 subtitle: "",
@@ -62,5 +96,38 @@ final class StudyListScreenTests: XCTestCase {
         )
     }
     
+    private func giveConsent(to study: Study) {
+        let expectation = expectation(description: "Study consent saved")
+        
+        study.saveUserConsentHasBeenGiven {
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    private func reflectedStudy(named label: String, in screen: StudyListScreen) -> Study? {
+        guard let value = reflectedValue(named: label, in: screen) else {
+            return nil
+        }
+        
+        if let study = value as? Study {
+            return study
+        }
+        
+        let optionalMirror = Mirror(reflecting: value)
+        return optionalMirror.children.first?.value as? Study
+    }
+    
+    private func reflectedStudies(named label: String, in screen: StudyListScreen) -> [Study] {
+        reflectedValue(named: label, in: screen) as? [Study] ?? []
+    }
+    
+    private func reflectedValue(named label: String, in screen: StudyListScreen) -> Any? {
+        Mirror(reflecting: screen)
+            .children
+            .first { $0.label == label }?
+            .value
+    }
+    
 }
-


### PR DESCRIPTION
- ignores studies without intro survey from being recommended to the user (since they rely solely on external recruitment)
- addresses an issue where terminationReason was not logged for LongTermStudies

…and includes addition to the debug view which I had not yet merged apparently